### PR TITLE
Move AndroidManifest elements to C# attributes

### DIFF
--- a/Wearable/AnalogWatchFaceService.cs
+++ b/Wearable/AnalogWatchFaceService.cs
@@ -34,10 +34,10 @@ namespace Google.XamarinSamples.WatchFace
 	// The watch face is drawn with less contrast in mute mode.
 	// 
 	// SweepWatchFaceService is similar but has a sweep second hand.
-    [Service (Label="Xamarin Analog Watchface", Permission="android.permission.BIND_WALLPAPER")]
-    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
-    [MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_analog")]
-    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
+	[Service (Label="Xamarin Analog Watchface", Permission="android.permission.BIND_WALLPAPER")]
+	[MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+	[MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_analog")]
+	[IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class AnalogWatchFaceService : CanvasWatchFaceService
 	{
 		const string Tag = "AnalogWatchFaceService";

--- a/Wearable/AnalogWatchFaceService.cs
+++ b/Wearable/AnalogWatchFaceService.cs
@@ -34,7 +34,10 @@ namespace Google.XamarinSamples.WatchFace
 	// The watch face is drawn with less contrast in mute mode.
 	// 
 	// SweepWatchFaceService is similar but has a sweep second hand.
-	[Service (Label = "AnalogWatchFaceService")]
+    [Service (Label="Xamarin Analog Watchface", Permission="android.permission.BIND_WALLPAPER")]
+    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+    [MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_analog")]
+    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class AnalogWatchFaceService : CanvasWatchFaceService
 	{
 		const string Tag = "AnalogWatchFaceService";

--- a/Wearable/DigitalWatchFaceService.cs
+++ b/Wearable/DigitalWatchFaceService.cs
@@ -39,7 +39,17 @@ namespace Google.XamarinSamples.WatchFace
 	// mode, the text is drawn without anti-aliasing in ambient mode. On devices which require burn-in
 	// protection, the hours are drawn in normal rather than bold. The time is drawn with less contrast
 	// and without seconds in mute mode.
-	[Service (Label = "DigitalWatchFaceService")]
+    [Service (Label = "Xamarin Digital Watchface", Permission="android.permission.BIND_WALLPAPER")]
+    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+    [MetaData ("com.google.android.wearable.watchface.preview", 
+        Resource="@drawable/preview_digital")]
+    [MetaData ("com.google.android.wearable.watchface.preview_circular", 
+        Resource="@drawable/preview_digital_circular")]
+    [MetaData ("com.google.android.wearable.watchface.companionConfigurationAction",
+            Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
+    [MetaData ("com.google.android.wearable.watchface.wearableConfigurationAction",
+            Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
+    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class DigitalWatchFaceService: CanvasWatchFaceService
 	{
 		const string Tag = "DigitalWatchFaceService";

--- a/Wearable/DigitalWatchFaceService.cs
+++ b/Wearable/DigitalWatchFaceService.cs
@@ -39,17 +39,17 @@ namespace Google.XamarinSamples.WatchFace
 	// mode, the text is drawn without anti-aliasing in ambient mode. On devices which require burn-in
 	// protection, the hours are drawn in normal rather than bold. The time is drawn with less contrast
 	// and without seconds in mute mode.
-    [Service (Label = "Xamarin Digital Watchface", Permission="android.permission.BIND_WALLPAPER")]
-    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
-    [MetaData ("com.google.android.wearable.watchface.preview", 
-        Resource="@drawable/preview_digital")]
-    [MetaData ("com.google.android.wearable.watchface.preview_circular", 
-        Resource="@drawable/preview_digital_circular")]
-    [MetaData ("com.google.android.wearable.watchface.companionConfigurationAction",
-            Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
-    [MetaData ("com.google.android.wearable.watchface.wearableConfigurationAction",
-            Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
-    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
+	[Service (Label = "Xamarin Digital Watchface", Permission="android.permission.BIND_WALLPAPER")]
+	[MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+	[MetaData ("com.google.android.wearable.watchface.preview", 
+		Resource="@drawable/preview_digital")]
+	[MetaData ("com.google.android.wearable.watchface.preview_circular", 
+		Resource="@drawable/preview_digital_circular")]
+	[MetaData ("com.google.android.wearable.watchface.companionConfigurationAction",
+		Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
+	[MetaData ("com.google.android.wearable.watchface.wearableConfigurationAction",
+		Value="google.xamarinsamples.watchface.CONFIG_DIGITAL")]
+	[IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class DigitalWatchFaceService: CanvasWatchFaceService
 	{
 		const string Tag = "DigitalWatchFaceService";

--- a/Wearable/Properties/AndroidManifest.xml
+++ b/Wearable/Properties/AndroidManifest.xml
@@ -15,38 +15,6 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="google.xamarinsamples.watchface">
 	<uses-sdk />
-	<uses-feature android:name="android.hardware.type.watch" />
-	<!-- Required to act as a custom watch face. -->
-	<uses-permission android:name="com.google.android.permission.PROVIDE_BACKGROUND" />
-	<uses-permission android:name="android.permission.WAKE_LOCK" />
-	<application android:label="Xamarin WatchFace Samples" android:icon="@drawable/icon">
-		<service android:name="google.xamarinsamples.watchface.AnalogWatchFaceService" android:label="Xamarin Analog Watchface" android:allowEmbedded="true" android:taskAffinity="" android:permission="android.permission.BIND_WALLPAPER">
-			<meta-data android:name="android.service.wallpaper" android:resource="@xml/watch_face" />
-			<meta-data android:name="com.google.android.wearable.watchface.preview" android:resource="@drawable/preview_analog" />
-			<intent-filter>
-				<action android:name="android.service.wallpaper.WallpaperService" />
-				<category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
-			</intent-filter>
-		</service>
-		<service android:name="google.xamarinsamples.watchface.SweepWatchFaceService" android:label="Xamarin Sweep Watchface" android:allowEmbedded="true" android:taskAffinity="" android:permission="android.permission.BIND_WALLPAPER">
-			<meta-data android:name="android.service.wallpaper" android:resource="@xml/watch_face" />
-			<meta-data android:name="com.google.android.wearable.watchface.preview" android:resource="@drawable/preview_sweep" />
-			<intent-filter>
-				<action android:name="android.service.wallpaper.WallpaperService" />
-				<category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
-			</intent-filter>
-		</service>
-		<service android:name="google.xamarinsamples.watchface.DigitalWatchFaceService" android:label="Xamarin Digital Watchface" android:allowEmbedded="true" android:taskAffinity="" android:permission="android.permission.BIND_WALLPAPER">
-			<meta-data android:name="android.service.wallpaper" android:resource="@xml/watch_face" />
-			<meta-data android:name="com.google.android.wearable.watchface.preview" android:resource="@drawable/preview_digital" />
-			<meta-data android:name="com.google.android.wearable.watchface.preview_circular" android:resource="@drawable/preview_digital_circular" />
-			<meta-data android:name="com.google.android.wearable.watchface.companionConfigurationAction" android:value="google.xamarinsamples.watchface.CONFIG_DIGITAL" />
-			<meta-data android:name="com.google.android.wearable.watchface.wearableConfigurationAction" android:value="google.xamarinsamples.watchface.CONFIG_DIGITAL" />
-			<intent-filter>
-				<action android:name="android.service.wallpaper.WallpaperService" />
-				<category android:name="com.google.android.wearable.watchface.category.WATCH_FACE" />
-			</intent-filter>
-		</service>
-		<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
+	<application android:label="Xamarin WatchFace Samples" android:icon="@drawable/icon">		
 	</application>
 </manifest>

--- a/Wearable/Properties/AssemblyInfo.cs
+++ b/Wearable/Properties/AssemblyInfo.cs
@@ -28,3 +28,8 @@ using Android.App;
 
 [assembly: Android.App.UsesFeature (Android.Content.PM.PackageManager.FeatureWatch)]
 [assembly: Application (Theme = "@android:style/Theme.DeviceDefault")]
+
+[assembly: UsesFeature ("android.hardware.type.watch")]
+[assembly: UsesPermission ("com.google.android.permission.PROVIDE_BACKGROUND")]
+[assembly: UsesPermission (Android.Manifest.Permission.WakeLock)]
+[assembly: MetaData ("com.google.android.gms.version", Value="@integer/google_play_services_version")]

--- a/Wearable/SweepWatchFaceService.cs
+++ b/Wearable/SweepWatchFaceService.cs
@@ -34,10 +34,10 @@ namespace Google.XamarinSamples.WatchFace
 	// The watch face is drawn with less contrast in mute mode.
 	// 
 	// AnalogWatchFaceService is similar but has a ticking second hand.
-    [Service (Label="Xamarin Sweep Watchface", Permission = "android.permission.BIND_WALLPAPER")]
-    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
-    [MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_sweep")]
-    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
+	[Service (Label="Xamarin Sweep Watchface", Permission = "android.permission.BIND_WALLPAPER")]
+	[MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+	[MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_sweep")]
+	[IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class SweepWatchFaceService : CanvasWatchFaceService
 	{
 		const string Tag = "SweepWatchFaceService";

--- a/Wearable/SweepWatchFaceService.cs
+++ b/Wearable/SweepWatchFaceService.cs
@@ -34,7 +34,10 @@ namespace Google.XamarinSamples.WatchFace
 	// The watch face is drawn with less contrast in mute mode.
 	// 
 	// AnalogWatchFaceService is similar but has a ticking second hand.
-	[Service (Label = "SweepWatchFaceService")]
+    [Service (Label="Xamarin Sweep Watchface", Permission = "android.permission.BIND_WALLPAPER")]
+    [MetaData ("android.service.wallpaper", Resource="@xml/watch_face")]
+    [MetaData ("com.google.android.wearable.watchface.preview", Resource="@drawable/preview_sweep")]
+    [IntentFilter (new [] { "android.service.wallpaper.WallpaperService" }, Categories=new [] { "com.google.android.wearable.watchface.category.WATCH_FACE" })]
 	public class SweepWatchFaceService : CanvasWatchFaceService
 	{
 		const string Tag = "SweepWatchFaceService";


### PR DESCRIPTION
Much of the AndroidManifest.xml markup can be declared as C# attributes instead, which will auto generate the correct manifest entries.

This will ensure the correct service class names ultimately make it into the manifest (especially as of Xamarin.Android 5.1 where there is a new technique for generating namespaces where they are not explicitly specified).
